### PR TITLE
quickstart/public-models

### DIFF
--- a/.quickstart/quickstart.yml
+++ b/.quickstart/quickstart.yml
@@ -19,10 +19,9 @@ destination_configurations:
 
 public_models: [
   "recurly__account_daily_overview",
-  "recurly__balance_transactions",
   "recurly__account_overview",
-  "recurly__subscription_overview",
+  "recurly__balance_transactions",
   "recurly__churn_analysis",
   "recurly__monthly_recurring_revenue",
-  "recurly__line_item_enhanced"
+  "recurly__subscription_overview"
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# dbt_recurly v0.5.1
+[PR #30](https://github.com/fivetran/dbt_recurly/pull/30) includes the following breaking changes:
+
+## Under the Hood
+- Updated `quickstart.yml` to list only the relevant `public_models`.
+
 # dbt_recurly v0.5.0
 [PR #29](https://github.com/fivetran/dbt_recurly/pull/29) includes the following breaking changes:
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'recurly'
-version: '0.5.0'
+version: '0.5.1'
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'recurly_integration_tests'
-version: '0.5.0'
+version: '0.5.1'
 profile: 'integration_tests'
 config-version: 2
 


### PR DESCRIPTION
Minor quickstart.yml change.

> [PR #30](https://github.com/fivetran/dbt_recurly/pull/30) includes the following breaking changes:
> 
> ## Under the Hood
> - Updated `quickstart.yml` to list only the relevant `public_models`.